### PR TITLE
Add support for Craft CMS 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 ## 1.0.0
 - Initial release
+
+## 2.0.0
+- FeedMe Filemaker now require Craft CMS version 5 and FeedMe version 6.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Enable Filemaker Data API to be used with the Feed-Me plugin
 
 ## Requirements
 
-This plugin requires Craft CMS 4.5.0 or later, and PHP 8.0.2 or later.
+This plugin requires Craft CMS 5.0.0 or later, Feed-Me 6.0.0 or later, and PHP 8.0.2 or later.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,11 @@
     "support": {
         "email": "stuart@x2network.net"
     },
-    "version": "1.0.1",
+    "version": "2.0.0",
     "require": {
         "php": ">=8.0.2",
-        "craftcms/cms": "^4.5.0"
+        "craftcms/cms": "^5.0.0",
+        "craftcms/feed-me": "^6.0.0"
     },
     "require-dev": {
         "craftcms/ecs": "dev-main",


### PR DESCRIPTION
* Add support for Craft 5.
* Remove the register template roots.
* Remove the get or set api token instead of requesting it every time it calls.
* Update changelog.